### PR TITLE
Enable ability to locally deploy to minikube

### DIFF
--- a/cicd/config.go
+++ b/cicd/config.go
@@ -1,10 +1,14 @@
 package cicd
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os/exec"
 	"strings"
+
+	"github.com/spf13/viper"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -56,6 +60,7 @@ type Provider struct {
 
 	Platform struct {
 		GKE
+		MiniKube
 	}
 
 	CD struct {
@@ -120,6 +125,38 @@ func (wf *Workflow) GetActiveCDProvider() (activeCD interface{}, err error) {
 		log.Println(err)
 	}
 	return activeCD, err
+}
+
+func (wf *Workflow) UseContext() (err error) {
+	var stderr bytes.Buffer
+	var cmdOut []byte
+	var ctx string
+
+	switch wf.Config.Provider.Platform.ID {
+	case "gke":
+		ctx = wf.Provider.Platform.GKE.Context
+	case "minikube":
+		ctx = wf.Provider.Platform.MiniKube.Context
+	default:
+		LogError(fmt.Errorf("unknown platform provider: <%v>", wf.Config.Provider.Platform.ID))
+	}
+
+	cmd := exec.Command("kubectl", "config", "use-context", ctx)
+	cmd.Stderr = &stderr
+
+	log.Println(viper.GetString("cmdMode"), strings.Join(cmd.Args, " "))
+
+	if !IsDryRun() {
+		cmd.Stderr = &stderr
+		if cmdOut, err = cmd.Output(); err != nil {
+			err = fmt.Errorf("%v", stderr.String())
+			return err
+		}
+		logCmdOutput(cmdOut)
+	}
+
+	return err
+
 }
 
 func logCmdOutput(cmdOut []byte) {

--- a/cicd/gke.go
+++ b/cicd/gke.go
@@ -6,4 +6,5 @@ type GKE struct {
 	Cluster     string
 	Computezone string
 	Keyfile     string
+	Context     string
 }

--- a/cicd/helm.go
+++ b/cicd/helm.go
@@ -22,6 +22,9 @@ type Helm struct {
 	Values    struct {
 		Template string
 		Output   string
+		Overrides struct {
+			Platform map[string]map[string]string
+		}
 	}
 }
 
@@ -61,8 +64,19 @@ func (h *Helm) Deploy(wf *Workflow) (err error) {
 		defer valuesFile.Close()
 	}
 
-	// render values file from template
-	err = renderHelmValuesFile(valuesFile, viper.GetString("repo"), viper.GetString("tag"))
+	// TODO: currently only one category (platform) and one value (service type) are enabled for overrider; extend to more categories and values
+	platform := wf.Config.Provider.Platform.ID
+	overrides := wf.Provider.CD.Helm.Values.Overrides.Platform
+	serviceType := overrides[platform]["servicetype"]
+
+	// render values file using template
+	err = renderHelmValuesFile(
+		valuesFile,
+		viper.GetString("repo"),
+		viper.GetString("tag"),
+		serviceType,
+	)
+
 	if err != nil {
 		return fmt.Errorf("renderHelmValuesFile(): %v", err)
 	}
@@ -93,13 +107,14 @@ func (h *Helm) Deploy(wf *Workflow) (err error) {
 	return err
 }
 
-func renderHelmValuesFile(valuesFile *os.File, repo string, tag string) error {
+func renderHelmValuesFile(valuesFile *os.File, repo string, tag string, serviceType string) error {
+
 	type Values struct {
 		Repo, Tag, ServiceType string
 	}
 
 	// Prepare some data to insert into the template.
-	var values = Values{Repo: repo, Tag: tag}
+	var values = Values{Repo: repo, Tag: tag, ServiceType: serviceType}
 
 	// initialize the template
 	var t *template.Template

--- a/cicd/minikube.go
+++ b/cicd/minikube.go
@@ -1,0 +1,6 @@
+package cicd
+
+type MiniKube struct {
+	Name    string
+	Context string
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -66,7 +66,7 @@ func deploy(ccmd *cobra.Command, args []string) error {
 	ad := activeCDProvider.(cicd.Deployer)
 
 	// use k8s context associated with platform
-	if err = cicd.UseContext(); err != nil {
+	if err = wf.UseContext(); err != nil {
 		return err
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -58,12 +58,17 @@ func deploy(ccmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// get active CD provider indicated by config and assert as Deployer
+	//get active CD provider indicated by config and assert as Deployer
 	var activeCDProvider interface{}
 	if activeCDProvider, err = wf.GetActiveCDProvider(); err != nil {
 		return err
 	}
 	ad := activeCDProvider.(cicd.Deployer)
+
+	// use k8s context associated with platform
+	if err = cicd.UseContext(); err != nil {
+		return err
+	}
 
 	// deploy using active CD provider
 	err = ad.Deploy(wf)


### PR DESCRIPTION
Introduce context attribute to platform.  Selected platform in config will drive switch to new k8s context.  Currently only useful running from cicd deploy ... from cli.

Next step: add CI provider jenkins running in minikube, then deploy within same k8s cluster.